### PR TITLE
separate pitch & upperLeft state

### DIFF
--- a/src/hooks/useGrid.ts
+++ b/src/hooks/useGrid.ts
@@ -1,12 +1,13 @@
-import { useRecoilState } from "recoil";
-import { pitchState, upperLeftState } from "../states/pointConfigState";
+import { useRecoilValue } from "recoil";
+import { pitchState } from "../states/pitchState";
 import { useWindowSize } from "./useWindowSize";
 import * as vp from "../helpers/virtualPoint";
 import { usePoint } from "./usePoint";
+import { upperLeftState } from "../states/upperLeftState";
 
 export const useGrid = () => {
-  const [pitch] = useRecoilState(pitchState);
-  const [upperLeft] = useRecoilState(upperLeftState);
+  const pitch = useRecoilValue(pitchState);
+  const upperLeft = useRecoilValue(upperLeftState);
 
   const { width, height } = useWindowSize();
   const { toReal } = usePoint();

--- a/src/hooks/usePoint.ts
+++ b/src/hooks/usePoint.ts
@@ -1,11 +1,12 @@
-import { useRecoilState } from "recoil";
-import { pitchState, upperLeftState } from "../states/pointConfigState";
+import { useRecoilValue } from "recoil";
+import { pitchState } from "../states/pitchState";
 import * as rp from "../helpers/realPoint";
 import * as vp from "../helpers/virtualPoint";
+import { upperLeftState } from "../states/upperLeftState";
 
 export const usePoint = () => {
-  const [pitch] = useRecoilState(pitchState);
-  const [upperLeft] = useRecoilState(upperLeftState);
+  const pitch = useRecoilValue(pitchState);
+  const upperLeft = useRecoilValue(upperLeftState);
 
   const toVirtual = (r: RealPoint) => {
     rp.toVirtual(r, pitch, upperLeft);

--- a/src/states/pitchState.ts
+++ b/src/states/pitchState.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const pitchState = atom<number>({
+  key: "pitchState",
+  default: 0,
+});

--- a/src/states/upperLeftState.ts
+++ b/src/states/upperLeftState.ts
@@ -1,11 +1,6 @@
 import { atom } from "recoil";
 import * as vp from "../helpers/virtualPoint";
 
-export const pitchState = atom<number>({
-  key: "pitchState",
-  default: 0,
-});
-
 export const upperLeftState = atom<VirtualPoint>({
   key: "upperLeftState",
   default: vp.create(0, 0),


### PR DESCRIPTION
とりあえずの方針として、
値を各stateにセットするようなカスタムフックはstate内部に配置
値を読み出したいときは、useRecoillValueを使ってhooks内部のカスタムフックから呼び出す

useRecoilStateをstates以外で使用しないようにする。