### PR TITLE
resetPreviewのuseEffectの位置を、レンダリング依存を増やさないまま表に移動させる

### DIFF
--- a/src/components/ButtonArea.tsx
+++ b/src/components/ButtonArea.tsx
@@ -3,12 +3,17 @@ import { HorizontalRule, ShowChart, TextFields } from "@mui/icons-material";
 import RectangleIcon from "@mui/icons-material/Rectangle";
 import CircleIcon from "@mui/icons-material/Circle";
 import { Fab, SvgIcon, Tooltip } from "@mui/material";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDrawMode } from "../states/drawModeState";
 import { ReactComponent as CursorIcon } from "../assets/CursorIcon.svg";
+import { useResetPreview } from "../hooks/useResetPreview";
 
 const ButtonArea: React.FC = () => {
   const { drawMode, changeMode } = useDrawMode();
+  const { resetPreview } = useResetPreview();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => resetPreview(), [drawMode]);
 
   return (
     <div style={{ float: "left", marginTop: 5 }}>

--- a/src/hooks/useResetPreview.ts
+++ b/src/hooks/useResetPreview.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useConfigModal } from "../states/configModalState";
 import { useDrawMode } from "../states/drawModeState";
 import { useSetSvgObject } from "../states/svgObjectState";
@@ -24,9 +23,6 @@ export const useResetPreview = () => {
         deleteSvgObject();
     }
   };
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => resetPreview(), [drawMode]);
 
   return {
     resetPreview,


### PR DESCRIPTION
流石にuseKey上ではちょっとなあ、という

でも結局全部keyControllerの子要素だし、更新されちゃってるのか？検証の必要あり